### PR TITLE
Fix readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -6,7 +6,7 @@ tags:
   - privileged
 ---
 
-# Component: `account`
+# Component: `account-settings`
 
 This component is responsible for provisioning account level settings: IAM password policy, AWS Account Alias, EBS
 encryption, and Service Quotas.


### PR DESCRIPTION
## what
- Copy CHANGELOG.md to `src/CHANGELOG.md`
- Generate `src/README.md` from `README.yaml`

## why
- `atmos vendor` should get readme files
