### PR TITLE
docs: remove outdated budget and service quota references from documentation

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -2,7 +2,7 @@
 _extends: .github
 repository:
   name: aws-account-settings
-  description: 'This component is responsible for provisioning account level settings: IAM password policy, AWS Account Alias, EBS encryption, and Service Quotas'
+  description: 'This component is responsible for provisioning account level settings: AWS Account Alias, EBS encryption, S3 block public access, alternate contacts, and SSM session preferences'
   homepage: https://cloudposse.com/accelerate
   topics: terraform, terraform-component
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@
 
 -->
 
-This component is responsible for provisioning account level settings: IAM password policy, AWS Account Alias, EBS
-encryption, and Service Quotas.
+This component is responsible for provisioning account level settings: AWS Account Alias, EBS encryption, S3 block public access, alternate contacts, and SSM session preferences.
 
 
 > [!TIP]
@@ -63,56 +62,26 @@ components:
     account-settings:
       vars:
         enabled: true
-        minimum_password_length: 20
-        maximum_password_age: 120
-        budgets_enabled: true
-        budgets_notifications_enabled: true
-        budgets_slack_webhook_url: https://url.slack.com/abcd/1234
-        budgets_slack_username: AWS Budgets
-        budgets_slack_channel: aws-budgets-notifications
-        budgets:
-          - name: 1000-total-monthly
-            budget_type: COST
-            limit_amount: "1000"
-            limit_unit: USD
-            time_unit: MONTHLY
-          - name: s3-3GB-limit-monthly
-            budget_type: USAGE
-            limit_amount: "3"
-            limit_unit: GB
-            time_unit: MONTHLY
-            notification:
-              - comparison_operator: GREATER_THAN
-                notification_type: FORECASTED
-                threshold_type: PERCENTAGE
-                threshold: 80
-                subscribers:
-                  - slack
-              - comparison_operator: GREATER_THAN
-                notification_type: FORECASTED
-                threshold_type: PERCENTAGE
-                # We generate two forecast notifications. This makes sure that notice is taken,
-                #   and hopefully action can be taken to prevent going over budget.
-                threshold: 100
-                subscribers:
-                  - slack
-              - comparison_operator: GREATER_THAN
-                notification_type: ACTUAL
-                threshold_type: PERCENTAGE
-                threshold: 100
-                subscribers:
-                  - slack
-        service_quotas_enabled: true
-        service_quotas:
-          - quota_name: Subnets per VPC
-            service_code: vpc
-            value: 250
-          - quota_code: L-E79EC296 # aka `Security Groups per Region`
-            service_code: vpc
-            value: 500
-          - quota_code: L-F678F1CE # aka `VPC per Region`
-            service_code: vpc
-            value: null
+        account_alias_enabled: true
+        s3_block_public_access_enabled: true
+        ebs_default_encryption_enabled: true
+        billing_contact:
+          name: "John Doe"
+          title: "CFO" 
+          email_address: "billing@example.com"
+          phone_number: "+1-555-123-4567"
+        operations_contact:
+          name: "Jane Smith"
+          title: "DevOps Lead"
+          email_address: "ops@example.com"
+          phone_number: "+1-555-234-5678"
+        security_contact:
+          name: "Bob Wilson"
+          title: "CISO"
+          email_address: "security@example.com"
+          phone_number: "+1-555-345-6789"
+        ssm_session_preferences_enabled: true
+        ssm_session_idle_timeout_minutes: 30
 ```
 
 <!-- prettier-ignore-start -->

--- a/README.yaml
+++ b/README.yaml
@@ -3,8 +3,7 @@ name: "aws-account-settings"
 github_repo: "cloudposse-terraform-components/aws-account-settings"
 # Short description of this project
 description: |-
-  This component is responsible for provisioning account level settings: IAM password policy, AWS Account Alias, EBS
-  encryption, and Service Quotas.
+  This component is responsible for provisioning account level settings: AWS Account Alias, EBS encryption, S3 block public access, alternate contacts, and SSM session preferences.
 usage: |-
   **Stack Level**: Global
 
@@ -18,56 +17,26 @@ usage: |-
       account-settings:
         vars:
           enabled: true
-          minimum_password_length: 20
-          maximum_password_age: 120
-          budgets_enabled: true
-          budgets_notifications_enabled: true
-          budgets_slack_webhook_url: https://url.slack.com/abcd/1234
-          budgets_slack_username: AWS Budgets
-          budgets_slack_channel: aws-budgets-notifications
-          budgets:
-            - name: 1000-total-monthly
-              budget_type: COST
-              limit_amount: "1000"
-              limit_unit: USD
-              time_unit: MONTHLY
-            - name: s3-3GB-limit-monthly
-              budget_type: USAGE
-              limit_amount: "3"
-              limit_unit: GB
-              time_unit: MONTHLY
-              notification:
-                - comparison_operator: GREATER_THAN
-                  notification_type: FORECASTED
-                  threshold_type: PERCENTAGE
-                  threshold: 80
-                  subscribers:
-                    - slack
-                - comparison_operator: GREATER_THAN
-                  notification_type: FORECASTED
-                  threshold_type: PERCENTAGE
-                  # We generate two forecast notifications. This makes sure that notice is taken,
-                  #   and hopefully action can be taken to prevent going over budget.
-                  threshold: 100
-                  subscribers:
-                    - slack
-                - comparison_operator: GREATER_THAN
-                  notification_type: ACTUAL
-                  threshold_type: PERCENTAGE
-                  threshold: 100
-                  subscribers:
-                    - slack
-          service_quotas_enabled: true
-          service_quotas:
-            - quota_name: Subnets per VPC
-              service_code: vpc
-              value: 250
-            - quota_code: L-E79EC296 # aka `Security Groups per Region`
-              service_code: vpc
-              value: 500
-            - quota_code: L-F678F1CE # aka `VPC per Region`
-              service_code: vpc
-              value: null
+          account_alias_enabled: true
+          s3_block_public_access_enabled: true
+          ebs_default_encryption_enabled: true
+          billing_contact:
+            name: "John Doe"
+            title: "CFO" 
+            email_address: "billing@example.com"
+            phone_number: "+1-555-123-4567"
+          operations_contact:
+            name: "Jane Smith"
+            title: "DevOps Lead"
+            email_address: "ops@example.com"
+            phone_number: "+1-555-234-5678"
+          security_contact:
+            name: "Bob Wilson"
+            title: "CISO"
+            email_address: "security@example.com"
+            phone_number: "+1-555-345-6789"
+          ssm_session_preferences_enabled: true
+          ssm_session_idle_timeout_minutes: 30
   ```
 
   <!-- prettier-ignore-start -->

--- a/src/README.md
+++ b/src/README.md
@@ -8,8 +8,7 @@ tags:
 
 # Component: `account-settings`
 
-This component is responsible for provisioning account level settings: IAM password policy, AWS Account Alias, EBS
-encryption, and Service Quotas.
+This component is responsible for provisioning account level settings: AWS Account Alias, EBS encryption, S3 block public access, alternate contacts, and SSM session preferences.
 ## Usage
 
 **Stack Level**: Global
@@ -24,56 +23,26 @@ components:
     account-settings:
       vars:
         enabled: true
-        minimum_password_length: 20
-        maximum_password_age: 120
-        budgets_enabled: true
-        budgets_notifications_enabled: true
-        budgets_slack_webhook_url: https://url.slack.com/abcd/1234
-        budgets_slack_username: AWS Budgets
-        budgets_slack_channel: aws-budgets-notifications
-        budgets:
-          - name: 1000-total-monthly
-            budget_type: COST
-            limit_amount: "1000"
-            limit_unit: USD
-            time_unit: MONTHLY
-          - name: s3-3GB-limit-monthly
-            budget_type: USAGE
-            limit_amount: "3"
-            limit_unit: GB
-            time_unit: MONTHLY
-            notification:
-              - comparison_operator: GREATER_THAN
-                notification_type: FORECASTED
-                threshold_type: PERCENTAGE
-                threshold: 80
-                subscribers:
-                  - slack
-              - comparison_operator: GREATER_THAN
-                notification_type: FORECASTED
-                threshold_type: PERCENTAGE
-                # We generate two forecast notifications. This makes sure that notice is taken,
-                #   and hopefully action can be taken to prevent going over budget.
-                threshold: 100
-                subscribers:
-                  - slack
-              - comparison_operator: GREATER_THAN
-                notification_type: ACTUAL
-                threshold_type: PERCENTAGE
-                threshold: 100
-                subscribers:
-                  - slack
-        service_quotas_enabled: true
-        service_quotas:
-          - quota_name: Subnets per VPC
-            service_code: vpc
-            value: 250
-          - quota_code: L-E79EC296 # aka `Security Groups per Region`
-            service_code: vpc
-            value: 500
-          - quota_code: L-F678F1CE # aka `VPC per Region`
-            service_code: vpc
-            value: null
+        account_alias_enabled: true
+        s3_block_public_access_enabled: true
+        ebs_default_encryption_enabled: true
+        billing_contact:
+          name: "John Doe"
+          title: "CFO" 
+          email_address: "billing@example.com"
+          phone_number: "+1-555-123-4567"
+        operations_contact:
+          name: "Jane Smith"
+          title: "DevOps Lead"
+          email_address: "ops@example.com"
+          phone_number: "+1-555-234-5678"
+        security_contact:
+          name: "Bob Wilson"
+          title: "CISO"
+          email_address: "security@example.com"
+          phone_number: "+1-555-345-6789"
+        ssm_session_preferences_enabled: true
+        ssm_session_idle_timeout_minutes: 30
 ```
 
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
## Summary

- Remove outdated budget and service quota configuration examples from documentation
- Update component description to reflect current simplified scope
- Update GitHub repository description with accurate feature list

## Background

Budget and service quota functionality was previously moved to separate `aws-budgets` and `aws-service-quotas` components, but the documentation still contained references and examples for these removed features. This PR cleans up the documentation to accurately reflect the component's current capabilities.

## Changes

- **README.yaml**: Updated description and replaced budget/service quota examples with current functionality examples
- **README.md**: Regenerated from updated README.yaml with clean examples
- **src/README.md**: Updated with current examples  
- **.github/settings.yml**: Updated repository description

## Current Component Scope

This component now focuses on core account settings:
- AWS Account Alias
- EBS encryption
- S3 block public access
- Alternate contacts (billing, operations, security)
- SSM session preferences

## Test plan

- [x] Verified no unused variables exist in Terraform files
- [x] Confirmed documentation examples match current variable schema
- [x] Regenerated README.md successfully with `atmos readme`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS Account Alias provisioning
  * Added S3 block public access configuration
  * Added alternate contact management (billing, operations, security)
  * Added SSM session preferences and idle timeout settings

* **Documentation**
  * Updated configuration documentation and usage examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->