### PR TITLE
Add version 2 migration warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@
 
 -->
 
+This component is responsible for provisioning account-level settings: AWS Account Alias, EBS encryption, S3 block public access, alternate contacts, SSM session preferences, EBS snapshot block public access, EC2 instance metadata defaults, EC2 AMI block public access, and EMR block public access configuration.
+
+
+> [!TIP]
+> #### 👽 Use Atmos with Terraform
+> Cloud Posse uses [`atmos`](https://atmos.tools) to easily orchestrate multiple environments using Terraform. <br/>
+> Works with [Github Actions](https://atmos.tools/integrations/github-actions/), [Atlantis](https://atmos.tools/integrations/atlantis), or [Spacelift](https://atmos.tools/integrations/spacelift).
+>
+> <details>
+> <summary><strong>Watch demo of using Atmos with Terraform</strong></summary>
+> <img src="https://github.com/cloudposse/atmos/blob/main/docs/demo.gif?raw=true"/><br/>
+> <i>Example of running <a href="https://atmos.tools"><code>atmos</code></a> to manage infrastructure from our <a href="https://atmos.tools/quick-start/">Quick Start</a> tutorial.</i>
+> </details>
+
+
+## Introduction
+
 > [!WARNING]
 > The latest version of this component (version 2) assumes you have Atmos Auth set up, and it has a very simple `providers.tf`.
 >
@@ -45,21 +62,6 @@
 > ```
 >
 > to overwrite the current one.
-
-This component is responsible for provisioning account-level settings: AWS Account Alias, EBS encryption, S3 block public access, alternate contacts, SSM session preferences, EBS snapshot block public access, EC2 instance metadata defaults, EC2 AMI block public access, and EMR block public access configuration.
-
-
-> [!TIP]
-> #### 👽 Use Atmos with Terraform
-> Cloud Posse uses [`atmos`](https://atmos.tools) to easily orchestrate multiple environments using Terraform. <br/>
-> Works with [Github Actions](https://atmos.tools/integrations/github-actions/), [Atlantis](https://atmos.tools/integrations/atlantis), or [Spacelift](https://atmos.tools/integrations/spacelift).
->
-> <details>
-> <summary><strong>Watch demo of using Atmos with Terraform</strong></summary>
-> <img src="https://github.com/cloudposse/atmos/blob/main/docs/demo.gif?raw=true"/><br/>
-> <i>Example of running <a href="https://atmos.tools"><code>atmos</code></a> to manage infrastructure from our <a href="https://atmos.tools/quick-start/">Quick Start</a> tutorial.</i>
-> </details>
-
 
 
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@
 
 -->
 
+> [!WARNING]
+> The latest version of this component (version 2) assumes you have Atmos Auth set up, and it has a very simple `providers.tf`.
+>
+> If you are still using `aws-teams` and `team-roles`, update your `component.yaml` to use `providers.depth-1.tf` from
+> [cloudposse-terraform-components/mixins](https://github.com/cloudposse-terraform-components/mixins/blob/main/src/mixins/providers.depth-1.tf) via:
+>
+> ```yaml
+> mixins:
+>   # Use upstream mixin for providers.tf without account-map dependency
+>   - uri: https://raw.githubusercontent.com/cloudposse-terraform-components/mixins/{{ .Version }}/src/mixins/providers.depth-1.tf
+>     version: v0.3.2
+>     filename: providers.tf
+> ```
+>
+> to overwrite the current one.
+
 This component is responsible for provisioning account-level settings: AWS Account Alias, EBS encryption, S3 block public access, alternate contacts, SSM session preferences, EBS snapshot block public access, EC2 instance metadata defaults, EC2 AMI block public access, and EMR block public access configuration.
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -2,6 +2,23 @@ name: "aws-account-settings"
 # Canonical GitHub repo
 github_repo: "cloudposse-terraform-components/aws-account-settings"
 # Short description of this project
+introduction: |-
+  > [!WARNING]
+  > The latest version of this component (version 2) assumes you have Atmos Auth set up, and it has a very simple `providers.tf`.
+  >
+  > If you are still using `aws-teams` and `team-roles`, update your `component.yaml` to use `providers.depth-1.tf` from
+  > [cloudposse-terraform-components/mixins](https://github.com/cloudposse-terraform-components/mixins/blob/main/src/mixins/providers.depth-1.tf) via:
+  >
+  > ```yaml
+  > mixins:
+  >   # Use upstream mixin for providers.tf without account-map dependency
+  >   - uri: https://raw.githubusercontent.com/cloudposse-terraform-components/mixins/{{ .Version }}/src/mixins/providers.depth-1.tf
+  >     version: v0.3.2
+  >     filename: providers.tf
+  > ```
+  >
+  > to overwrite the current one.
+
 description: |-
   This component is responsible for provisioning account-level settings: AWS Account Alias, EBS encryption, S3 block public access, alternate contacts, SSM session preferences, EBS snapshot block public access, EC2 instance metadata defaults, EC2 AMI block public access, and EMR block public access configuration.
 usage: |-


### PR DESCRIPTION
## Summary

Added a GitHub warning admonition to the README documenting the breaking changes in version 2 of the component, which assumes Atmos Auth is configured and includes a simplified providers.tf file. Provides migration instructions for users still using aws-teams and team-roles to leverage the cloudposse-terraform-components/mixins mixin as a workaround.

## Test Plan

- [x] Review README warning admonition displays correctly
- [x] Verify migration instructions are complete and accurate
- [x] Check GitHub rendering of the admonition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an introductory warning in the README about the v2 requirement for Atmos Auth.
  * Included migration guidance and a YAML snippet showing how to update providers configuration for upgrading to v2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->