### PR TITLE
feat(ssm): add support to block public document sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ components:
 | [aws_iam_account_alias.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_alias) | resource |
 | [aws_s3_account_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
 | [aws_ssm_document.session_manager_prefs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_document) | resource |
+| [aws_ssm_service_setting.block_public_document_sharing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_service_setting) | resource |
 
 ## Inputs
 
@@ -204,6 +205,7 @@ components:
 | <a name="input_s3_ignore_public_acls"></a> [s3\_ignore\_public\_acls](#input\_s3\_ignore\_public\_acls) | Whether to ignore public ACLs | `bool` | `true` | no |
 | <a name="input_s3_restrict_public_buckets"></a> [s3\_restrict\_public\_buckets](#input\_s3\_restrict\_public\_buckets) | Whether to restrict public buckets | `bool` | `true` | no |
 | <a name="input_security_contact"></a> [security\_contact](#input\_security\_contact) | Security alternate contact information | <pre>object({<br/>    name          = string<br/>    title         = string<br/>    email_address = string<br/>    phone_number  = string<br/>  })</pre> | `null` | no |
+| <a name="input_ssm_block_public_document_sharing"></a> [ssm\_block\_public\_document\_sharing](#input\_ssm\_block\_public\_document\_sharing) | Whether to block public document sharing in SSM | `bool` | `false` | no |
 | <a name="input_ssm_session_idle_timeout_minutes"></a> [ssm\_session\_idle\_timeout\_minutes](#input\_ssm\_session\_idle\_timeout\_minutes) | The idle session timeout in minutes for SSM Session Manager. AWS default is 20 minutes. | `number` | `20` | no |
 | <a name="input_ssm_session_preferences_enabled"></a> [ssm\_session\_preferences\_enabled](#input\_ssm\_session\_preferences\_enabled) | Whether to configure SSM Session Manager preferences (idle timeout) | `bool` | `false` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
@@ -226,6 +228,7 @@ components:
 | <a name="output_operations_contact_configured"></a> [operations\_contact\_configured](#output\_operations\_contact\_configured) | Whether operations contact was configured |
 | <a name="output_s3_public_access_block_configured"></a> [s3\_public\_access\_block\_configured](#output\_s3\_public\_access\_block\_configured) | Whether S3 public access block was configured |
 | <a name="output_security_contact_configured"></a> [security\_contact\_configured](#output\_security\_contact\_configured) | Whether security contact was configured |
+| <a name="output_ssm_block_public_document_sharing_configured"></a> [ssm\_block\_public\_document\_sharing\_configured](#output\_ssm\_block\_public\_document\_sharing\_configured) | Whether SSM block public document sharing was configured |
 | <a name="output_ssm_session_idle_timeout_minutes"></a> [ssm\_session\_idle\_timeout\_minutes](#output\_ssm\_session\_idle\_timeout\_minutes) | The configured SSM session idle timeout in minutes |
 | <a name="output_ssm_session_preferences_configured"></a> [ssm\_session\_preferences\_configured](#output\_ssm\_session\_preferences\_configured) | Whether SSM Session Manager preferences were configured |
 <!-- markdownlint-restore -->

--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ components:
         ec2_instance_metadata_defaults_enabled: true
         ec2_image_block_public_access_enabled: true
         emr_block_public_access_enabled: true
+        ssm_block_public_document_sharing: true
         billing_contact:
           name: "John Doe"
-          title: "CFO" 
+          title: "CFO"
           email_address: "billing@example.com"
           phone_number: "+1-555-123-4567"
         operations_contact:

--- a/README.yaml
+++ b/README.yaml
@@ -41,9 +41,10 @@ usage: |-
           ec2_instance_metadata_defaults_enabled: true
           ec2_image_block_public_access_enabled: true
           emr_block_public_access_enabled: true
+          ssm_block_public_document_sharing: true
           billing_contact:
             name: "John Doe"
-            title: "CFO" 
+            title: "CFO"
             email_address: "billing@example.com"
             phone_number: "+1-555-123-4567"
           operations_contact:

--- a/src/README.md
+++ b/src/README.md
@@ -106,6 +106,7 @@ components:
 | [aws_iam_account_alias.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_alias) | resource |
 | [aws_s3_account_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
 | [aws_ssm_document.session_manager_prefs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_document) | resource |
+| [aws_ssm_service_setting.block_public_document_sharing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_service_setting) | resource |
 
 ## Inputs
 
@@ -152,6 +153,7 @@ components:
 | <a name="input_s3_ignore_public_acls"></a> [s3\_ignore\_public\_acls](#input\_s3\_ignore\_public\_acls) | Whether to ignore public ACLs | `bool` | `true` | no |
 | <a name="input_s3_restrict_public_buckets"></a> [s3\_restrict\_public\_buckets](#input\_s3\_restrict\_public\_buckets) | Whether to restrict public buckets | `bool` | `true` | no |
 | <a name="input_security_contact"></a> [security\_contact](#input\_security\_contact) | Security alternate contact information | <pre>object({<br/>    name          = string<br/>    title         = string<br/>    email_address = string<br/>    phone_number  = string<br/>  })</pre> | `null` | no |
+| <a name="input_ssm_block_public_document_sharing"></a> [ssm\_block\_public\_document\_sharing](#input\_ssm\_block\_public\_document\_sharing) | Whether to block public document sharing in SSM | `bool` | `false` | no |
 | <a name="input_ssm_session_idle_timeout_minutes"></a> [ssm\_session\_idle\_timeout\_minutes](#input\_ssm\_session\_idle\_timeout\_minutes) | The idle session timeout in minutes for SSM Session Manager. AWS default is 20 minutes. | `number` | `20` | no |
 | <a name="input_ssm_session_preferences_enabled"></a> [ssm\_session\_preferences\_enabled](#input\_ssm\_session\_preferences\_enabled) | Whether to configure SSM Session Manager preferences (idle timeout) | `bool` | `false` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
@@ -174,6 +176,7 @@ components:
 | <a name="output_operations_contact_configured"></a> [operations\_contact\_configured](#output\_operations\_contact\_configured) | Whether operations contact was configured |
 | <a name="output_s3_public_access_block_configured"></a> [s3\_public\_access\_block\_configured](#output\_s3\_public\_access\_block\_configured) | Whether S3 public access block was configured |
 | <a name="output_security_contact_configured"></a> [security\_contact\_configured](#output\_security\_contact\_configured) | Whether security contact was configured |
+| <a name="output_ssm_block_public_document_sharing_configured"></a> [ssm\_block\_public\_document\_sharing\_configured](#output\_ssm\_block\_public\_document\_sharing\_configured) | Whether SSM block public document sharing was configured |
 | <a name="output_ssm_session_idle_timeout_minutes"></a> [ssm\_session\_idle\_timeout\_minutes](#output\_ssm\_session\_idle\_timeout\_minutes) | The configured SSM session idle timeout in minutes |
 | <a name="output_ssm_session_preferences_configured"></a> [ssm\_session\_preferences\_configured](#output\_ssm\_session\_preferences\_configured) | Whether SSM Session Manager preferences were configured |
 <!-- markdownlint-restore -->

--- a/src/README.md
+++ b/src/README.md
@@ -47,9 +47,10 @@ components:
         ec2_instance_metadata_defaults_enabled: true
         ec2_image_block_public_access_enabled: true
         emr_block_public_access_enabled: true
+        ssm_block_public_document_sharing: true
         billing_contact:
           name: "John Doe"
-          title: "CFO" 
+          title: "CFO"
           email_address: "billing@example.com"
           phone_number: "+1-555-123-4567"
         operations_contact:

--- a/src/main.tf
+++ b/src/main.tf
@@ -112,3 +112,9 @@ resource "aws_emr_block_public_access_configuration" "this" {
     }
   }
 }
+
+resource "aws_ssm_service_setting" "block_public_document_sharing" {
+  count         = local.enabled && var.ssm_block_public_document_sharing ? 1 : 0
+  setting_id    = "/ssm/documents/console/public-sharing-permission"
+  setting_value = "Disable"
+}

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -28,6 +28,11 @@ output "security_contact_configured" {
   description = "Whether security contact was configured"
 }
 
+output "ssm_block_public_document_sharing_configured" {
+  value       = local.enabled && var.ssm_block_public_document_sharing
+  description = "Whether SSM block public document sharing was configured"
+}
+
 output "ssm_session_preferences_configured" {
   value       = local.enabled && var.ssm_session_preferences_enabled
   description = "Whether SSM Session Manager preferences were configured"

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -90,6 +90,12 @@ variable "security_contact" {
   default     = null
 }
 
+variable "ssm_block_public_document_sharing" {
+  type        = bool
+  description = "Whether to block public document sharing in SSM"
+  default     = false
+}
+
 variable "ssm_session_preferences_enabled" {
   type        = bool
   description = "Whether to configure SSM Session Manager preferences (idle timeout)"


### PR DESCRIPTION
## what

* Added support to block public document sharing in SSM

## why

* Blocks public access for any new SSM documents

> Before you begin, review all publicly shared SSM documents in your AWS account and confirm whether you want to continue sharing them. To stop sharing an SSM document with the public, you must modify the document permission setting as described in the [Modify permissions for a shared SSM document](https://docs.aws.amazon.com/systems-manager/latest/userguide/documents-ssm-sharing.html#modify-permissions-shared) section of this topic. Turning on the block public sharing setting doesn't affect any SSM documents you're currently sharing with the public. With the block public sharing setting enabled, you won’t be able to share any additional SSM documents with the public.

## references

* https://docs.aws.amazon.com/systems-manager/latest/userguide/documents-ssm-sharing.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to block public document sharing in AWS Systems Manager Documents (disabled by default).

* **Documentation**
  * Updated module/component docs and usage example to document the new input and an output that indicates whether the setting was applied.
  * Minor formatting cleanup in an example (removed trailing space).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->